### PR TITLE
Rd 7634/fix stat crea pipeline

### DIFF
--- a/airbyte-integrations/connectors/source-elastic-search-v2/source_elastic_search_v2/source.py
+++ b/airbyte-integrations/connectors/source-elastic-search-v2/source_elastic_search_v2/source.py
@@ -35,7 +35,6 @@ There are additional required TODOs in the files within the integration_tests fo
 # Basic full refresh stream
 class ElasticSearchV2Stream(HttpStream, ABC):
     url_base = "http://aes-statistic01.prod.dld:9200"
-    doc_count = 0
     date_start = ""
 
     def __init__(self, date_start):
@@ -57,7 +56,6 @@ class ElasticSearchV2Stream(HttpStream, ABC):
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         docs = response.json()["hits"]["hits"]
         pit_id = response.json()["pit_id"]
-        self.doc_count += len(docs)
         if response.status_code == 200 and docs != []:
             search_after = docs[len(docs) - 1].get("sort")
             return {"search_after": search_after, "pit_id": pit_id}
@@ -160,6 +158,7 @@ class ElasticSearchV2Stream(HttpStream, ABC):
 
         for hit in hits:
             data = hit["_source"]
+            data["_id"] = hit["_id"]
             yield data
 
 

--- a/airbyte-integrations/connectors/source-elastic-search-v2/source_elastic_search_v2/spec.yaml
+++ b/airbyte-integrations/connectors/source-elastic-search-v2/source_elastic_search_v2/spec.yaml
@@ -3,3 +3,10 @@ connectionSpecification:
   $schema: http://json-schema.org/draft-07/schema#
   title: Elastic Search V2 Spec
   type: object
+  required:
+    - date_start
+  additionalProperties: false
+  properties:
+    date_start:
+      type: string
+      description: Start date of the synchronization


### PR DESCRIPTION
Add a point in time creation in Elastic Search to freeze the state of the index when we start the sync as recommended by ES : [](https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html)

Use date_start as parameter so we can choose any start date (not just 2020-01-01)
